### PR TITLE
feat(popup): allow popup to have custom children

### DIFF
--- a/examples/complete.tsx
+++ b/examples/complete.tsx
@@ -77,8 +77,9 @@ export function Complete() {
             closeOnClick={false}
             closeButton={false}
             position={[11.40416, 47.26475]}
-            content="Popup"
-          />
+          >
+            Popup
+          </Popup>
         </Map>
         <Map
           id="second-map"

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,28 +1,29 @@
 import { useMapEffect } from "./map.jsx";
 import * as maplibre from "maplibre-gl";
-import { onCleanup, splitProps } from "solid-js";
+import { onCleanup, createRenderEffect, splitProps, children, type FlowProps } from "solid-js";
 
-export type PopUpProps = Partial<maplibre.PopupOptions> & {
+export type PopUpProps = FlowProps<Partial<maplibre.PopupOptions> & {
   position?: maplibre.LngLatLike;
-  content?: string;
-};
+}, Node>;
 
 export function Popup(initial: PopUpProps) {
-  const [props, options] = splitProps(initial, ["position", "content"]);
+  const [props, options] = splitProps(initial, ["position", "children"]);
 
-  let popup: maplibre.Popup | undefined;
+  const popup = new maplibre.Popup(options);
+
+  const kids = children(() => props.children)
+  
+  createRenderEffect(() => popup.setDOMContent(kids()));
 
   useMapEffect((map) => {
-    if (!popup) popup = new maplibre.Popup(options);
-
-    if (props.position && props.content) {
-      popup.setLngLat(props.position).setHTML(props.content).addTo(map);
+    if (props.position) {
+      popup.setLngLat(props.position).addTo(map);
     } else {
       popup.remove();
     }
   });
 
-  onCleanup(() => popup?.remove());
+  onCleanup(() => popup.remove());
 
   return <></>;
 }


### PR DESCRIPTION
This allows `Popup` to have custom children, instead of having to pass in something like `innerHtml`.